### PR TITLE
nix: introduce fake nixpkgs

### DIFF
--- a/images/nix/default.nix
+++ b/images/nix/default.nix
@@ -53,7 +53,7 @@ let
         "ENV=/etc/profile.d/nix.sh"
         "BASH_ENV=/etc/profile.d/nix.sh"
         "NIX_BUILD_SHELL=/bin/bash"
-        "NIX_PATH=nixpkgs=${toString <nixpkgs>}"
+        "NIX_PATH=nixpkgs=${./fake_nixpkgs}"
         "PAGER=cat"
         "PATH=/usr/bin:/bin"
         "SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt"

--- a/images/nix/fake_nixpkgs/default.nix
+++ b/images/nix/fake_nixpkgs/default.nix
@@ -1,0 +1,7 @@
+_:
+throw ''
+This container doesn't include nixpkgs.
+
+Pin your dependencies. Or if you must, override the NIX_PATH environment
+variable with eg: "NIX_PATH=nixpkgs=channel:nixos-unstable"
+''


### PR DESCRIPTION
Since <nixpkgs> wasn't working, might as well make the error more
explicit. That way, users are quickly aware if they forgot to pin their
nixpkgs.