### PR TITLE
README.md: merge the 2 "Related projects" sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,6 @@ Then run `nix-build -A <image-name>` to test that it builds, and
 then use
 `docker load -i /nix/store/...<image-name>.tar.gz` to load and test the image.
 
-## Related projects
-
-The [docker-library](https://github.com/docker-library/official-images#readme)
-is an image set maintained by the Docker Inc. team and contain
-officially-supported images.
-
 ## User Feedback
 
 ### Issues
@@ -121,6 +115,10 @@ we are always thrilled to receive pull requests, and do our brest ot process
 them as fast as we can.
 
 ## Related projects
+
+* The [docker-library](https://github.com/docker-library/official-images#readme)
+  is an image set maintained by the Docker Inc. team and contain
+  officially-supported images.
 
 * [Nixery](https://nixery.dev/) is a pretty cool service that builds docker
   images from nixpkgs attributes on the fly.


### PR DESCRIPTION
There were two sections called "Related projects" in the `README.md`, each listing only one other project. This change merges them into a single section listing both those projects.