### PR TITLE
Adding gnugrep to cachix image

### DIFF
--- a/images/cachix/default.nix
+++ b/images/cachix/default.nix
@@ -4,7 +4,7 @@
 }:
 (docker-nixpkgs.nix.override {
   nix = nix;
-  extraContents = [ cachix ];
+  extraContents = [ cachix gnugrep ];
 }).overrideAttrs (prev: {
   meta = (prev.meta or {}) // {
     description = "Nix and Cachix image";


### PR DESCRIPTION
I have seen in `install-cachix-actions` that they use `gnugrep`. While we cannot do `nix-env -iA nixpkgs.gnugrep` inside the image, I prefer to put `gnugrep` by default in `cachix` image.