### PR TITLE
feat: added a nixStatic docker image

### DIFF
--- a/images/nix-unstable-static/README.md
+++ b/images/nix-unstable-static/README.md
@@ -1,0 +1,8 @@
+# nix-unstable-static
+
+This is a special variant of the nix image that contains no `/nix/store`.
+Instead, nix and all the supporting binaries are statically built and copied
+into /bin.
+
+The main use-case is to be able to run nix in the container, but share the
+`/nix/store` with the host.

--- a/images/nix-unstable-static/default.nix
+++ b/images/nix-unstable-static/default.nix
@@ -1,0 +1,116 @@
+{ dockerTools
+, lib
+, fetchurl
+, findutils
+, pkgsStatic
+, python3
+, removeReferencesTo
+, runCommand
+}:
+let
+  inherit (pkgsStatic)
+    bash
+    busybox
+    cacert
+    openssl
+    ;
+
+  # Get nix from Hydra because the nixpkgs one is not fully static
+  nixStaticBin = fetchurl {
+    url = "https://hydra.nixos.org/build/181573550/download/1/nix";
+    hash = "sha256-zO2xJhQIrLtL/ReTlcorjwsaTO1W5Rnr+sXwcLcujok=";
+  };
+
+  nixSymlinks = [
+    "nix-build"
+    "nix-channel"
+    "nix-collect-garbage"
+    "nix-copy-closure"
+    "nix-daemon"
+    "nix-env"
+    "nix-hash"
+    "nix-instantiate"
+    "nix-prefetch-url"
+    "nix-shell"
+    "nix-store"
+  ];
+
+  dirs = [
+    "bin"
+    "etc/ssl/certs"
+    "root"
+    "tmp"
+    "usr"
+  ];
+
+  extraCommands = ''
+    rm_ref() {
+      ${removeReferencesTo}/bin/remove-references-to "$@"
+    }
+
+    # Create a FHS-like file structure
+    cp -r ${../nix/root}/* .
+    chmod +w etc
+    mkdir -p ${toString dirs}
+
+    # For /usr/bin/env
+    ln -s ../bin usr/bin
+
+    # Make sure /tmp has the right permissions
+    chmod 1777 tmp
+
+    # Add SSL CA certs
+    cp -a "${cacert}/etc/ssl/certs/ca-bundle.crt" etc/ssl/certs/ca-bundle.crt
+
+    # Install base binaries
+    cp -a ${busybox}/bin/* bin/
+    rm_ref -t ${busybox} bin/busybox
+
+    # Install shell
+    cp -a ${bash}/bin/bash bin/
+    rm_ref -t ${bash} bin/bash
+
+    # Install nix
+    cp -a ${nixStaticBin} bin/nix
+    chmod +x bin/nix
+    for sym in ${toString nixSymlinks}; do
+      ln -sv /bin/nix bin/$sym
+    done
+    mkdir -p libexec/nix
+    ln -s /bin/nix libexec/nix/build-remote
+  '';
+
+  # To debug
+  unpacked = runCommand
+    "unpacked"
+    { buildInputs = [ python3 ]; }
+    ''
+      mkdir layer
+      pushd layer
+      ${extraCommands}
+      popd
+      mv layer $out
+    '';
+
+  image = dockerTools.buildImage {
+    name = "nix-static";
+
+    inherit extraCommands;
+
+    config = {
+      Cmd = [ "/bin/bash" ];
+      Env = [
+        "NIX_BUILD_SHELL=/bin/bash"
+        "PAGER=cat"
+        "PATH=/bin"
+        "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
+      ];
+    };
+  };
+in
+image // {
+  passthru = image.passthru // { inherit unpacked; };
+  meta = image.meta // {
+    description = "Nix but statically built";
+  };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -13,5 +13,7 @@ mkShell {
   shellHook = ''
     # try to work aroud build issues
     unset TMPDIR
+
+    export NIX_PATH=nixpkgs=${toString nixpkgs}
   '';
 }

--- a/shell.nix
+++ b/shell.nix
@@ -5,6 +5,7 @@ in
 with pkgs;
 mkShell {
   buildInputs = [
+    dive
     jq
     skopeo
   ] ++ lib.optional (pkgs ? mdsh) pkgs.mdsh;


### PR DESCRIPTION
an annoying thing about static nix:
```
bash-5.1# nix-env -iA glibc -f https://github.com/NixOS/nixpkgs/archive/23f71e9427c7cd2a6f87a167b4f6dc170b4431df.tar.gz  
unpacking 'https://github.com/NixOS/nixpkgs/archive/23f71e9427c7cd2a6f87a167b4f6dc170b4431df.tar.gz'...
error: attribute 'unsafeDiscardStringContext' missing, at /nix/store/r3n7lyc3sb64qx18ai1qay1gx18c07dy-23f71e9427c7cd2a6f87a167b4f6dc170b4431df.tar.gz/lib/strings.nix:442:13
```