### PR TITLE
fix: Enable Nix `experimental-features` in `cachix-flakes` image 

### DIFF
--- a/images/cachix-flakes/default.nix
+++ b/images/cachix-flakes/default.nix
@@ -1,6 +1,10 @@
 { docker-nixpkgs
-, nixFlakes
+, cachix
 }:
-docker-nixpkgs.cachix.override {
-  nix = nixFlakes;
-}
+(docker-nixpkgs.nix-flakes.override {
+  extraContents = [ cachix ];
+}).overrideAttrs (prev: {
+  meta = (prev.meta or { }) // {
+    description = "Nix and Cachix image";
+  };
+})

--- a/images/cachix/default.nix
+++ b/images/cachix/default.nix
@@ -1,9 +1,7 @@
 { docker-nixpkgs
 , cachix
-, nix
 }:
 (docker-nixpkgs.nix.override {
-  nix = nix;
   extraContents = [ cachix ];
 }).overrideAttrs (prev: {
   meta = (prev.meta or { }) // {

--- a/images/nix-flakes/default.nix
+++ b/images/nix-flakes/default.nix
@@ -1,6 +1,7 @@
 { docker-nixpkgs
 , nixFlakes
 , writeTextFile
+, extraContents ? [ ]
 }:
 docker-nixpkgs.nix.override {
   nix = nixFlakes;
@@ -12,5 +13,5 @@ docker-nixpkgs.nix.override {
         experimental-features = nix-command flakes
       '';
     })
-  ];
+  ] ++ extraContents;
 }


### PR DESCRIPTION
By default, the `flakes` experimental feature is disabled in the [`cachix-flakes`](../tree/master/images/cachix-flakes/default.nix) image