### PR TITLE
feat: Allow Nix to accept `nixConfig` by default

### DIFF
--- a/images/nix-flakes/default.nix
+++ b/images/nix-flakes/default.nix
@@ -10,6 +10,7 @@ docker-nixpkgs.nix.override {
       name = "nix.conf";
       destination = "/etc/nix/nix.conf";
       text = ''
+        accept-flake-config = true
         experimental-features = nix-command flakes
       '';
     })


### PR DESCRIPTION
This is useful when Nix (with Flakes enabled) is used with Continuous Integration in order to perform actions on a project having `nixConfig` defined in `flake.nix`