### PR TITLE
Generate multi-arch image manifests

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -39,3 +39,27 @@ jobs:
           CI_REGISTRY_AUTH: '${{ secrets.REGISTRY_AUTH }}'
           NIXPKGS_CHANNEL: '${{ matrix.channel }}'
           NIX_SYSTEM_NAME: '${{ matrix.system }}'
+
+  push-manifest:
+    needs: [build]
+    strategy:
+      fail-fast: false
+      matrix:
+        channel:
+          - nixos-unstable
+          - nixos-23.05
+          - nixos-23.11
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          extra-conf: |
+            extra-platforms = aarch64-linux
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - run: nix-shell --run ./ci-manifests.sh
+        env:
+          CI_REGISTRY_AUTH: '${{ secrets.REGISTRY_AUTH }}'
+          NIXPKGS_CHANNEL: '${{ matrix.channel }}'
+          NIX_SYSTEM_NAME: '${{ matrix.system }}'

--- a/ci-manifests.sh
+++ b/ci-manifests.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# CI specific build script.
+#
+set -euo pipefail
+
+channel=${NIXPKGS_CHANNEL:-nixos-unstable}
+registry=${CI_REGISTRY:-docker.io}
+registry_auth=${CI_REGISTRY_AUTH:-}
+image_prefix=${CI_PROJECT_PATH:-nixpkgs}
+
+if [[ $channel == nixos-unstable ]]; then
+  image_tag=latest
+else
+  image_tag=$channel
+fi
+
+export NIX_PATH=channel:$channel
+
+banner() {
+  echo "========================================================"
+  echo "  $*"
+  echo "========================================================"
+}
+
+cd "$(dirname "$0")"
+
+if [[ $(git rev-parse --abbrev-ref HEAD) != master ]]; then
+  banner "Skipping push on non-master branch"
+  exit
+fi
+
+if [[ -n "${registry_auth}" ]]; then
+  banner "docker login"
+  ./docker-login "$registry_auth" "$registry"
+fi
+
+banner "generate manifests"
+./generate-manifests "$registry" "$image_prefix" "$image_tag"

--- a/generate-manifests
+++ b/generate-manifests
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Usage: ./push-all <registry> <image-prefix> <image-tag>
+set -euo pipefail
+
+registry=${1:-docker.io}
+image_prefix=${2:-nixpkgs}
+image_tag=${3:-latest}
+system_name=${NIX_SYSTEM_NAME:-x86_64-linux}
+
+releases_json=$(nix-instantiate --strict --argstr system "$system_name" --eval --json)
+
+echo "=== Generating manifests for $registry"
+
+for attr in $(echo "$releases_json" | jq -r "keys[]") ; do
+  repository=$registry/$image_prefix/$attr
+  target_image=${repository}:${image_tag}
+  echo "--- attr=$attr target=$target_image"
+  podman manifest create "$target_image"
+  podman manifest add "$target_image" "docker://$repository:${image_tag}-x86_64-linux"
+  podman manifest add "$target_image" "docker://$repository:${image_tag}-aarch64-linux"
+  podman manifest push --all "$target_image" "docker://$target_image"
+done
+
+echo OK

--- a/push-all
+++ b/push-all
@@ -15,7 +15,7 @@ echo "=== Pushing images to $registry"
 for attr in $(echo "$releases_json" | jq -r "keys[]") ; do
   file=$(echo "$releases_json" | jq -r ".\"$attr\"")
   src=docker-archive://$file
-  dst=docker://$registry/$image_prefix/$attr:$image_tag
+  dst=docker://$registry/$image_prefix/$attr:${image_tag}-${system_name}
   echo "--- attr=$attr src=$src dst=$dst"
   skopeo copy --insecure-policy "$src" "$dst"
 done

--- a/shell.nix
+++ b/shell.nix
@@ -8,6 +8,7 @@ mkShell {
     dive
     jq
     skopeo
+    podman
   ] ++ lib.optional (pkgs ? mdsh) pkgs.mdsh;
 
   shellHook = ''

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,5 @@
 let
-  nixpkgs = builtins.fetchTarball "channel:nixos-22.05";
+  nixpkgs = builtins.fetchTarball "channel:nixos-23.11";
   pkgs = import nixpkgs { config = { }; overlays = [ ]; };
 in
 with pkgs;


### PR DESCRIPTION
Closes https://github.com/nix-community/docker-nixpkgs/issues/76

I have tested this and it does work as expected. The only downside I see is that it pollutes the repositories with extra labels (`<channel>-aarch64-linux` and `<channel>-x86_64-linux` respectively)
