### PR TITLE
build linux images on darwin

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,14 @@
 {
   system ? builtins.currentSystem
 }: let
-  pkgs = import ./pkgs.nix system;
+  _parts = builtins.split "-" system;
+  arch = builtins.elemAt _parts 0;
+  os = builtins.elemAt _parts 2;
+  system' =
+    if os == "darwin"
+    then "${arch}-linux"
+    else system;
+  pkgs =
+    import ./pkgs.nix system';
 in
 pkgs.docker-nixpkgs


### PR DESCRIPTION
The assert in pkgs.nix currently just throws if you try to build on darwin. As there's no such thing as darwin in a container, I believe it should be safe to assume that people want to build linux containers.

This defaults to the current platform, but still lets users specify system to i.e. build x86_64-linux containers from an aarch64-darwin host.