### PR TITLE
Docker image of NixOS with Devbox preinstalled

### DIFF
--- a/images/devbox/default.nix
+++ b/images/devbox/default.nix
@@ -1,0 +1,6 @@
+{ buildCLIImage
+, devbox
+}:
+buildCLIImage {
+  drv = devbox;
+}


### PR DESCRIPTION
# NixOS Docker Image for MacOS Development

This Docker image streamlines development on MacOS, particularly for aarch64-darwin systems. It solves two key challenges:

1. Enables compilation of non-darwin Nix configurations on aarch64-darwin
2. Provides Jetpack.io's Devbox as an intuitive package manager

## Key Features
- Uses Devbox for dependency management through a simple `devbox.json` file at project root
- Offers a user-friendly abstraction layer over Nix
- No prior Nix knowledge required
- Seamless integration with MacOS development workflow

Perfect for developers who want Nix's power without its complexity, especially when working with cross-platform builds on Apple Silicon.