### PR TITLE
Add support for 25.05

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -19,6 +19,7 @@ jobs:
           - nixos-unstable
           - nixos-24.05
           - nixos-24.11
+          - nixos-25.05
         system:
           - aarch64-linux
           - x86_64-linux
@@ -67,6 +68,7 @@ jobs:
           - nixos-unstable
           - nixos-24.05
           - nixos-24.11
+          - nixos-25.05
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,3 +12,4 @@ build:
       - NIXPKGS_CHANNEL:
           - nixos-24.05
           - nixos-24.11
+          - nixos-25.05

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ nixpkgs channel describes.
 | ---            | ---         | ---                                               |
 | nixos-24.05    | nixos-24.05 | only minor versions that include security updates |
 | nixos-24.11    | nixos-24.11 | only minor versions that include security updates |
+| nixos-25.05    | nixos-25.05 | only minor versions that include security updates |
 | nixos-unstable | latest      | latest and greatest, major versions might change  |
 
 ## List of images

--- a/images/devcontainer/default.nix
+++ b/images/devcontainer/default.nix
@@ -42,7 +42,11 @@ let
       nix
 
       # runtime dependencies of nix
-      cacert
+      # HACK: don't include the "hashed" output. It has overlapping files with
+      #       the "unbundled" output, and that breaks the build.
+      (cacert // {
+        outputs = builtins.filter (x: x != "hashed") cacert.outputs;
+      })
       gitReallyMinimal
       gnutar
       gzip


### PR DESCRIPTION
Based this on the PR for 24.11. I had to apply a similar hack to cacert as the one that already exists for gcc since the hashed and unbundled outputs conflict. According to the [PR](https://github.com/NixOS/nixpkgs/pull/370023) which added the hashed output it is only needed for a few games.

I have only made sure that building the images succeeds.