### PR TITLE
nix.conf: enable parallel building

### DIFF
--- a/images/nix-flakes/default.nix
+++ b/images/nix-flakes/default.nix
@@ -12,6 +12,7 @@ docker-nixpkgs.nix.override {
       text = ''
         accept-flake-config = true
         experimental-features = nix-command flakes
+        max-jobs = auto
       '';
     })
   ] ++ extraContents;

--- a/images/nix-unstable-static/default.nix
+++ b/images/nix-unstable-static/default.nix
@@ -84,11 +84,12 @@ let
     mkdir -p libexec/nix
     ln -s /bin/nix libexec/nix/build-remote
 
-    # Enable flakes
+    # Enable flakes and parallel building
     mkdir -p etc/nix
     cat <<NIX_CONFIG > etc/nix/nix.conf
     accept-flake-config = true
     experimental-features = nix-command flakes
+    max-jobs = auto
     NIX_CONFIG
 
     # Add run-as-user script


### PR DESCRIPTION
#### Copy of commit msg
This is a sensible default given Docker images are often used for CI and build jobs.

#### Discussion
For a long time I've used `docker-nixpkgs` for CI builds, and I've only recently noticed that parallel building is disabled by default, leading to decreased build perf.

I'm uncertain about the potential drawbacks of this change in specific edge cases, so I'm opening it up for discussion.