### PR TITLE
images/pocket-id: init

### DIFF
--- a/images/pocket-id/default.nix
+++ b/images/pocket-id/default.nix
@@ -1,0 +1,6 @@
+{ buildCLIImage
+, pocket-id
+}:
+buildCLIImage {
+  drv = pocket-id;
+}


### PR DESCRIPTION
Tested locally:

<details>

<summary>Pic</summary>

![2025-06-30T21:41:56,060226728+10:00](https://github.com/user-attachments/assets/41c59cc3-a321-4c0d-8935-7d60396adebb)

</details>