### PR TITLE
images/attic: init

### DIFF
--- a/images/attic/default.nix
+++ b/images/attic/default.nix
@@ -1,0 +1,10 @@
+{ docker-nixpkgs
+, attic-client
+}:
+(docker-nixpkgs.nix.override {
+  extraContents = [ attic-client ];
+}).overrideAttrs (prev: {
+  meta = (prev.meta or { }) // {
+    description = "Nix and Attic client image";
+  };
+})


### PR DESCRIPTION
Crate image with `attic-client` for [attic](https://github.com/zhaofengli/attic). This image is closely modeled after the cachix image.