### PR TITLE
images/nix: allow passing extra commands

### DIFF
--- a/images/nix/default.nix
+++ b/images/nix/default.nix
@@ -12,6 +12,7 @@
 , xz
 , extraContents ? [ ]
 , extraEnv ? [ ]
+, extraExtraCommands ? ""
 }:
 let
   image = dockerTools.buildImageWithNixDb {
@@ -46,7 +47,7 @@ let
 
       # need a HOME
       mkdir -vp root
-    '';
+    '' + extraExtraCommands;
 
     config = {
       Cmd = [ "/bin/bash" ];


### PR DESCRIPTION
Allows you to add additional `extraCommands` to the image (e.g. to create more directories). I'm not really sure about the naming, I made it follow the convention of the `extra-` suffix, but `extraExtraCommands` does seem a bit silly. Then again, silly argument naming isn't anything new for Nix.